### PR TITLE
Added essential Zenject classes to link.xml file

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/link.xml
+++ b/UnityProject/Assets/Plugins/Zenject/link.xml
@@ -1,0 +1,15 @@
+<linker>
+    <assembly fullname="zenject">
+        <type fullname="Zenject.ZenjectManagersInstaller" preserve="all"/>
+        <type fullname="Zenject.SceneContextRegistry" preserve="all"/>
+        <type fullname="Zenject.PlaceholderFactory*" preserve="all"/>
+        <type fullname="Zenject.SceneContextRegistryAdderAndRemover" preserve="all"/>
+        <type fullname="Zenject.SignalBusInstaller" preserve="all" />
+        <type fullname="Zenject.SignalDeclarationAsyncInitializer" preserve="all" />
+        <type fullname="Zenject.SignalDeclaration" preserve="all" />
+        <type fullname="Zenject.SignalSubscription" preserve="all" />
+        <type fullname="Zenject.SignalSubscription/Pool" preserve="all" />
+        <type fullname="Zenject.SignalBus" preserve="all" />
+        <type fullname="*/Factory*" preserve="all" />
+    </assembly>
+</linker>

--- a/UnityProject/Assets/Plugins/Zenject/link.xml.meta
+++ b/UnityProject/Assets/Plugins/Zenject/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9fd6295dc2d5c464c99755a86603cb10
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
Without link.xml, some Zenject classes which are essential for the program to run correctly get stripped out. 

## What is the new behavior?
I added all the classes (which I could find) to the link.xml. With this change, turning Manage Stripping Level to High in Player Settings shouldn't be an issue. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No