### PR TITLE
Added compatibility with Unity's Enter The Play Mode feature

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/DictionaryPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/DictionaryPool.cs
@@ -19,6 +19,7 @@ namespace Zenject
         }
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/DictionaryPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/DictionaryPool.cs
@@ -18,6 +18,14 @@ namespace Zenject
             get { return _instance; }
         }
 
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _instance.Clear();
+        }
+#endif
+
         static void OnSpawned(Dictionary<TKey, TValue> items)
         {
             Assert.That(items.IsEmpty());

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/DictionaryPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/DictionaryPool.cs
@@ -23,6 +23,11 @@ namespace Zenject
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _instance.Clear();
         }
 #endif

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/HashSetPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/HashSetPool.cs
@@ -19,6 +19,7 @@ namespace Zenject
         }
         
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/HashSetPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/HashSetPool.cs
@@ -17,6 +17,14 @@ namespace Zenject
         {
             get { return _instance; }
         }
+        
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _instance.Clear();
+        }
+#endif
 
         static void OnSpawned(HashSet<T> items)
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/HashSetPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/HashSetPool.cs
@@ -23,6 +23,11 @@ namespace Zenject
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _instance.Clear();
         }
 #endif

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/ListPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/ListPool.cs
@@ -16,6 +16,11 @@ namespace Zenject
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _instance.Clear();
         }
 #endif

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/ListPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/ListPool.cs
@@ -10,6 +10,14 @@ namespace Zenject
         {
             OnDespawnedMethod = OnDespawned;
         }
+        
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _instance.Clear();
+        }
+#endif
 
         public static ListPool<T> Instance
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/ListPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/Util/ListPool.cs
@@ -12,6 +12,7 @@ namespace Zenject
         }
         
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -93,7 +93,7 @@ namespace Zenject
 #if UNITY_EDITOR
             // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
             // https://docs.unity3d.com/Manual/SceneReloading.html
-            if ((EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
+            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
             {
                _normalInstallers.Clear();
                _normalInstallerTypes.Clear();

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.Serialization;
 #if UNITY_EDITOR
 using UnityEditor;
+
 #endif
 
 namespace Zenject
@@ -17,13 +18,10 @@ namespace Zenject
         [SerializeField]
         List<ScriptableObjectInstaller> _scriptableObjectInstallers = new List<ScriptableObjectInstaller>();
 
-        [FormerlySerializedAs("Installers")]
-        [FormerlySerializedAs("_installers")]
-        [SerializeField]
+        [FormerlySerializedAs("Installers")] [FormerlySerializedAs("_installers")] [SerializeField]
         List<MonoInstaller> _monoInstallers = new List<MonoInstaller>();
 
-        [SerializeField]
-        List<MonoInstaller> _installerPrefabs = new List<MonoInstaller>();
+        [SerializeField] List<MonoInstaller> _installerPrefabs = new List<MonoInstaller>();
 
         List<InstallerBase> _normalInstallers = new List<InstallerBase>();
         List<Type> _normalInstallerTypes = new List<Type>();
@@ -82,10 +80,7 @@ namespace Zenject
             }
         }
 
-        public abstract DiContainer Container
-        {
-            get;
-        }
+        public abstract DiContainer Container { get; }
         public abstract IEnumerable<GameObject> GetRootGameObjects();
 
         protected virtual void Awake()
@@ -93,14 +88,30 @@ namespace Zenject
 #if UNITY_EDITOR
             // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
             // https://docs.unity3d.com/Manual/SceneReloading.html
-            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
-            {
-               _normalInstallers.Clear();
-               _normalInstallerTypes.Clear();
-            }
+            EditorApplication.playModeStateChanged += OnEditorPlayModeChanged;
 #endif
         }
+        
+#if UNITY_EDITOR
+        void OnEditorPlayModeChanged(PlayModeStateChange obj)
+        {
+            if (!EditorSettings.enterPlayModeOptionsEnabled)
+                return;
 
+            // If Scene Reload is enabled, we don't need to reset instance fields.
+            if ((EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) == 0)
+                return;
+
+            if (obj == PlayModeStateChange.EnteredEditMode)
+                ResetInstanceFields();
+        }
+
+        protected virtual void ResetInstanceFields()
+        {
+            _normalInstallers.Clear();
+            _normalInstallerTypes.Clear();
+        }
+#endif
 
         public void AddNormalInstallerType(Type installerType)
         {
@@ -127,7 +138,8 @@ namespace Zenject
 #else
                 Assert.That(PrefabUtility.GetPrefabType(installer.gameObject) != PrefabType.Prefab,
 #endif
-                    "Found prefab with name '{0}' in the Installer property of Context '{1}'.  You should use the property 'InstallerPrefabs' for this instead.", installer.name, name);
+                    "Found prefab with name '{0}' in the Installer property of Context '{1}'.  You should use the property 'InstallerPrefabs' for this instead.",
+                    installer.name, name);
 #endif
             }
 
@@ -139,18 +151,20 @@ namespace Zenject
                 // (eg. loading an asset bundle with a scene containing a scene context when inside unity editor)
 //#if UNITY_EDITOR
                 //Assert.That(PrefabUtility.GetPrefabType(installerPrefab.gameObject) == PrefabType.Prefab,
-                    //"Found non-prefab with name '{0}' in the InstallerPrefabs property of Context '{1}'.  You should use the property 'Installer' for this instead",
-                    //installerPrefab.name, this.name);
+                //"Found non-prefab with name '{0}' in the InstallerPrefabs property of Context '{1}'.  You should use the property 'Installer' for this instead",
+                //installerPrefab.name, this.name);
 //#endif
                 Assert.That(installerPrefab.GetComponent<MonoInstaller>() != null,
-                    "Expected to find component with type 'MonoInstaller' on given installer prefab '{0}'", installerPrefab.name);
+                    "Expected to find component with type 'MonoInstaller' on given installer prefab '{0}'",
+                    installerPrefab.name);
             }
         }
 
         protected void InstallInstallers()
         {
             InstallInstallers(
-                _normalInstallers, _normalInstallerTypes, _scriptableObjectInstallers, _monoInstallers, _installerPrefabs);
+                _normalInstallers, _normalInstallerTypes, _scriptableObjectInstallers, _monoInstallers,
+                _installerPrefabs);
         }
 
         protected void InstallInstallers(
@@ -207,7 +221,7 @@ namespace Zenject
 
             foreach (var installerType in normalInstallerTypes)
             {
-                var installer = (InstallerBase)Container.Instantiate(installerType);
+                var installer = (InstallerBase) Container.Instantiate(installerType);
 
 #if ZEN_INTERNAL_PROFILING
                 using (ProfileTimers.CreateTimedBlock("User Code"))
@@ -265,7 +279,7 @@ namespace Zenject
                 if (this is SceneContext)
                 {
                     if (binding.Context == null && binding.UseSceneContext
-                        && binding.gameObject.scene == gameObject.scene)
+                                                && binding.gameObject.scene == gameObject.scene)
                     {
                         binding.Context = this;
                     }
@@ -329,7 +343,8 @@ namespace Zenject
                     }
                     case ZenjectBinding.BindTypes.AllInterfacesAndSelf:
                     {
-                        Container.Bind(componentType.Interfaces().Concat(new[] { componentType }).ToArray()).WithId(identifier).FromInstance(component);
+                        Container.Bind(componentType.Interfaces().Concat(new[] {componentType}).ToArray())
+                            .WithId(identifier).FromInstance(component);
                         break;
                     }
                     default:

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -88,6 +88,19 @@ namespace Zenject
         }
         public abstract IEnumerable<GameObject> GetRootGameObjects();
 
+        protected virtual void Awake()
+        {
+#if UNITY_EDITOR
+            // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
+            // https://docs.unity3d.com/Manual/SceneReloading.html
+            if ((EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
+            {
+               _normalInstallers.Clear();
+               _normalInstallerTypes.Clear();
+            }
+#endif
+        }
+
 
         public void AddNormalInstallerType(Type installerType)
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
@@ -41,9 +41,23 @@ namespace Zenject
         }
 
         [Inject]
-        public void Construct(
-            DiContainer parentContainer)
+        public void Construct(DiContainer parentContainer)
         {
+#if UNITY_EDITOR
+            // We don't reset instance fields in Awake because Construct method gets called before Awake
+            
+            // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
+            // https://docs.unity3d.com/Manual/SceneReloading.html
+            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            {
+                PreInstall = null;
+                PostInstall = null;
+                PreResolve = null;
+                PostResolve = null;
+                _hasInstalled = false;
+            }
+#endif
+
             Assert.IsNull(_parentContainer);
             _parentContainer = parentContainer;
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using Zenject.Internal;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 #pragma warning disable 649
 
 namespace Zenject
@@ -48,7 +52,7 @@ namespace Zenject
             
             // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
             // https://docs.unity3d.com/Manual/SceneReloading.html
-            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
             {
                 PreInstall = null;
                 PostInstall = null;
@@ -56,6 +60,7 @@ namespace Zenject
                 PostResolve = null;
                 _hasInstalled = false;
                 _parentContainer = null;
+                _container = null;
             }
 #endif
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
@@ -7,10 +7,6 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using Zenject.Internal;
 
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
-
 #pragma warning disable 649
 
 namespace Zenject
@@ -47,28 +43,26 @@ namespace Zenject
         [Inject]
         public void Construct(DiContainer parentContainer)
         {
-#if UNITY_EDITOR
-            // We don't reset instance fields in Awake because Construct method gets called before Awake
-            
-            // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
-            // https://docs.unity3d.com/Manual/SceneReloading.html
-            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
-            {
-                PreInstall = null;
-                PostInstall = null;
-                PreResolve = null;
-                PostResolve = null;
-                _hasInstalled = false;
-                _parentContainer = null;
-                _container = null;
-            }
-#endif
-
             Assert.IsNull(_parentContainer);
             _parentContainer = parentContainer;
 
             Initialize();
         }
+
+#if UNITY_EDITOR
+        protected override void ResetInstanceFields()
+        {
+            base.ResetInstanceFields();
+            
+            PreInstall = null;
+            PostInstall = null;
+            PreResolve = null;
+            PostResolve = null;
+            _hasInstalled = false;
+            _parentContainer = null;
+            _container = null;
+        }
+#endif
 
         protected override void RunInternal()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
@@ -55,6 +55,7 @@ namespace Zenject
                 PreResolve = null;
                 PostResolve = null;
                 _hasInstalled = false;
+                _parentContainer = null;
             }
 #endif
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -170,6 +170,18 @@ namespace Zenject
             }
         }
 
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            PreInstall = null;
+            PostInstall = null;
+            PreResolve = null;
+            PostResolve = null;
+            _instance = null;
+        }
+#endif
+
         public bool ParentNewObjectsUnderContext
         {
             get { return _parentNewObjectsUnderContext; }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -199,8 +199,11 @@ namespace Zenject
             // Do nothing - Initialize occurs in Instance property
         }
 
-        public void Awake()
+        protected override void Awake()
         {
+            // We don't call base.Awake here because ProjectContext gets instantiated every time. 
+            
+            
             if (Application.isPlaying)
                 // DontDestroyOnLoad can only be called when in play mode and otherwise produces errors
                 // ProjectContext is created during design time (in an empty scene) when running validation

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -175,6 +175,11 @@ namespace Zenject
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             PreInstall = null;
             PostInstall = null;
             PreResolve = null;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -171,6 +171,7 @@ namespace Zenject
         }
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
@@ -23,7 +23,7 @@ namespace Zenject
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
-            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            if (!EditorSettings.enterPlayModeOptionsEnabled)
             {
                 return;
             }
@@ -32,17 +32,14 @@ namespace Zenject
         }
 #endif
 
-        protected override void Awake()
-        {
-            base.Awake();
-            
 #if UNITY_EDITOR
-            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
-            {
-                Initialized = false;
-            }
-#endif
+        protected override void ResetInstanceFields()
+        {
+            base.ResetInstanceFields();
+            
+            Initialized = false;
         }
+#endif
 
         protected void Initialize()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
@@ -1,5 +1,5 @@
-﻿using ModestTree;
-
+﻿using System.ComponentModel;
+using ModestTree;
 #if !NOT_UNITY3D
 using UnityEngine;
 
@@ -13,16 +13,33 @@ namespace Zenject
 
         static bool _staticAutoRun = true;
 
+        public bool Initialized { get; private set; }
+        
 #if UNITY_EDITOR
         // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _staticAutoRun = true;
         }
 #endif
-        
-        public bool Initialized { get; private set; }
+
+        protected override void Awake()
+        {
+            base.Awake();
+            
+#if UNITY_EDITOR
+            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            {
+                Initialized = false;
+            }
+#endif
+        }
 
         protected void Initialize()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
@@ -14,6 +14,7 @@ namespace Zenject
         static bool _staticAutoRun = true;
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using ModestTree;
+﻿using ModestTree;
 #if !NOT_UNITY3D
 using UnityEngine;
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
@@ -2,6 +2,10 @@
 #if !NOT_UNITY3D
 using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Zenject
 {
     public abstract class RunnableContext : Context
@@ -33,7 +37,7 @@ namespace Zenject
             base.Awake();
             
 #if UNITY_EDITOR
-            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
             {
                 Initialized = false;
             }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/RunnableContext.cs
@@ -1,7 +1,7 @@
 ﻿using ModestTree;
-using UnityEngine;
 
 #if !NOT_UNITY3D
+using UnityEngine;
 
 namespace Zenject
 {
@@ -13,6 +13,14 @@ namespace Zenject
 
         static bool _staticAutoRun = true;
 
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _staticAutoRun = true;
+        }
+#endif
+        
         public bool Initialized { get; private set; }
 
         protected void Initialize()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
@@ -125,22 +125,7 @@ namespace Zenject
         protected override void Awake()
         {
             base.Awake();
-#if UNITY_EDITOR
-            // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
-            // https://docs.unity3d.com/Manual/SceneReloading.html
-            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
-            {
-                _container = null;
-                _decoratorContexts.Clear();
-                _hasInstalled = false;
-                _hasResolved = false;
-                PreInstall = null;
-                PostInstall = null;
-                PreResolve = null;
-                PostResolve = null;
-            }
-#endif
-            
+
 #if ZEN_INTERNAL_PROFILING
             ProfileTimers.ResetAll();
             using (ProfileTimers.CreateTimedBlock("Other"))
@@ -149,6 +134,22 @@ namespace Zenject
                 Initialize();
             }
         }
+
+#if UNITY_EDITOR
+        protected override void ResetInstanceFields()
+        {
+            base.ResetInstanceFields();
+            
+            _container = null;
+            _decoratorContexts.Clear();
+            _hasInstalled = false;
+            _hasResolved = false;
+            PreInstall = null;
+            PostInstall = null;
+            PreResolve = null;
+            PostResolve = null;
+        }
+#endif
 
         public void Validate()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
@@ -10,6 +10,10 @@ using UnityEngine.Serialization;
 using Zenject.Internal;
 using UnityEngine.Events;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Zenject
 {
     public class SceneContext : RunnableContext
@@ -108,7 +112,7 @@ namespace Zenject
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
-            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            if (!EditorSettings.enterPlayModeOptionsEnabled)
             {
                 return;
             }
@@ -124,7 +128,7 @@ namespace Zenject
 #if UNITY_EDITOR
             // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
             // https://docs.unity3d.com/Manual/SceneReloading.html
-            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
             {
                 _container = null;
                 _decoratorContexts.Clear();

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
@@ -103,6 +103,15 @@ namespace Zenject
             set { _parentNewObjectsUnderSceneContext = value; }
         }
 
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            ExtraBindingsInstallMethod = null;
+            ParentContainers = null;
+            ExtraBindingsLateInstallMethod = null;
+        }
+#endif
         public void Awake()
         {
 #if ZEN_INTERNAL_PROFILING

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
@@ -104,6 +104,7 @@ namespace Zenject
         }
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
@@ -80,6 +80,16 @@ namespace Zenject
 
         public void Initialize(DiContainer container)
         {
+#if UNITY_EDITOR
+            // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
+            // https://docs.unity3d.com/Manual/SceneReloading.html
+            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            {
+                _injectableMonoBehaviours.Clear();
+                _container = null;
+            }
+#endif
+            
             Assert.IsNull(_container);
             Assert.That(_injectableMonoBehaviours.IsEmpty());
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
@@ -7,10 +7,6 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using Zenject.Internal;
 
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
-
 namespace Zenject
 {
     public class SceneDecoratorContext : Context
@@ -84,16 +80,6 @@ namespace Zenject
 
         public void Initialize(DiContainer container)
         {
-#if UNITY_EDITOR
-            // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
-            // https://docs.unity3d.com/Manual/SceneReloading.html
-            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
-            {
-                _injectableMonoBehaviours.Clear();
-                _container = null;
-            }
-#endif
-            
             Assert.IsNull(_container);
             Assert.That(_injectableMonoBehaviours.IsEmpty());
 
@@ -106,6 +92,16 @@ namespace Zenject
                 container.QueueForInject(instance);
             }
         }
+
+#if UNITY_EDITOR
+        protected override void ResetInstanceFields()
+        {
+            base.ResetInstanceFields();
+            
+            _injectableMonoBehaviours.Clear();
+            _container = null;
+        }
+#endif
 
         public void InstallDecoratorSceneBindings()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using Zenject.Internal;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Zenject
 {
     public class SceneDecoratorContext : Context
@@ -83,7 +87,7 @@ namespace Zenject
 #if UNITY_EDITOR
             // When Scene Reloading is disabled in Enter The Play Mode settings, we need to reset all non-serialized fields
             // https://docs.unity3d.com/Manual/SceneReloading.html
-            if ((UnityEditor.EditorSettings.enterPlayModeOptions & UnityEditor.EnterPlayModeOptions.DisableSceneReload) != 0)
+            if (EditorSettings.enterPlayModeOptionsEnabled && (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableSceneReload) != 0)
             {
                 _injectableMonoBehaviours.Clear();
                 _container = null;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/StaticContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/StaticContext.cs
@@ -11,7 +11,9 @@ namespace Zenject
     {
         static DiContainer _container;
 
-        // Useful sometimes to call from play mode tests
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
         public static void Clear()
         {
             _container = null;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/StaticContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/StaticContext.cs
@@ -12,6 +12,7 @@ namespace Zenject
         static DiContainer _container;
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif
         public static void Clear()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/DisposeBlock.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/DisposeBlock.cs
@@ -12,6 +12,14 @@ namespace Zenject
 
         List<IDisposable> _disposables;
         List<SpawnedObjectPoolPair> _objectPoolPairs;
+        
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _pool.Clear();
+        }
+#endif
 
         static void OnSpawned(DisposeBlock that)
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/DisposeBlock.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/DisposeBlock.cs
@@ -14,6 +14,7 @@ namespace Zenject
         List<SpawnedObjectPoolPair> _objectPoolPairs;
         
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/DisposeBlock.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/DisposeBlock.cs
@@ -18,6 +18,11 @@ namespace Zenject
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _pool.Clear();
         }
 #endif

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileBlock.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileBlock.cs
@@ -21,6 +21,7 @@ namespace Zenject
         {
         }
         
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileBlock.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileBlock.cs
@@ -25,6 +25,11 @@ namespace Zenject
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _instance = new ProfileBlock();
             _nameCache.Clear();
             _blockCount = 0;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileBlock.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileBlock.cs
@@ -20,6 +20,14 @@ namespace Zenject
         ProfileBlock()
         {
         }
+        
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _instance = new ProfileBlock();
+            _nameCache.Clear();
+            _blockCount = 0;
+        }
 
         public static Thread UnityMainThread
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileTimers.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileTimers.cs
@@ -15,6 +15,9 @@ namespace Zenject
     {
         static Dictionary<string, TimerInfo> _timers = new Dictionary<string, TimerInfo>();
 
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
         public static void ResetAll()
         {
             foreach (var timer in _timers.Values)

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileTimers.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ProfileTimers.cs
@@ -16,6 +16,7 @@ namespace Zenject
         static Dictionary<string, TimerInfo> _timers = new Dictionary<string, TimerInfo>();
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif
         public static void ResetAll()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/TypeAnalyzer.cs
@@ -40,6 +40,7 @@ namespace Zenject
         }
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/TypeAnalyzer.cs
@@ -39,6 +39,15 @@ namespace Zenject
             get; set;
         }
 
+#if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _typeInfo.Clear();
+            _allowDuringValidation.Clear();
+        }
+#endif
+
         public static bool ShouldAllowDuringValidation<T>()
         {
             return ShouldAllowDuringValidation(typeof(T));

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/TypeAnalyzer.cs
@@ -44,6 +44,11 @@ namespace Zenject
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _typeInfo.Clear();
             _allowDuringValidation.Clear();
         }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenReflectionTypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenReflectionTypeAnalyzer.cs
@@ -26,6 +26,7 @@ namespace Zenject.Internal
 
         // Only keep the attribute in define to avoid code duplication in static constructor and ResetStaticValues method
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif
         static void ResetStaticValues()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenReflectionTypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenReflectionTypeAnalyzer.cs
@@ -31,6 +31,7 @@ namespace Zenject.Internal
 #endif
         static void ResetStaticValues()
         {
+            // This gets called from static constructor so we won't check if enter the playmode option is enabled or not
             _injectAttributeTypes.Clear();
             _injectAttributeTypes.Add(typeof(InjectAttributeBase));
             ConstructorChoiceStrategy = ConstructorChoiceStrategy.InjectAttributeThenLeastArguments;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenReflectionTypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenReflectionTypeAnalyzer.cs
@@ -16,14 +16,23 @@ namespace Zenject.Internal
         static ReflectionTypeAnalyzer()
         {
             _injectAttributeTypes = new HashSet<Type>();
-            _injectAttributeTypes.Add(typeof(InjectAttributeBase));
-
-            ConstructorChoiceStrategy = ConstructorChoiceStrategy.InjectAttributeThenLeastArguments;
+            ResetStaticValues();
         }
 
         public static ConstructorChoiceStrategy ConstructorChoiceStrategy 
         {
             get; set;
+        }
+
+        // Only keep the attribute in define to avoid code duplication in static constructor and ResetStaticValues method
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void ResetStaticValues()
+        {
+            _injectAttributeTypes.Clear();
+            _injectAttributeTypes.Add(typeof(InjectAttributeBase));
+            ConstructorChoiceStrategy = ConstructorChoiceStrategy.InjectAttributeThenLeastArguments;
         }
 
         public static void AddCustomInjectAttribute<T>()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
@@ -21,6 +21,11 @@ namespace Zenject.Internal
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {
+            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                return;
+            }
+            
             _disabledIndestructibleGameObject = null;
         }
 #endif

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
@@ -17,6 +17,7 @@ namespace Zenject.Internal
 #endif
 
 #if UNITY_EDITOR
+        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void ResetStaticValues()
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
@@ -16,6 +16,13 @@ namespace Zenject.Internal
         static GameObject _disabledIndestructibleGameObject;
 #endif
 
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticValues()
+        {
+            _disabledIndestructibleGameObject = null;
+        }
+#endif
         // Due to the way that Unity overrides the Equals operator,
         // normal null checks such as (x == null) do not always work as
         // expected


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
If Domain Reloading is disabled, static fields will keep their values between play sessions in Unity editor. 

If Scene Reloading is disabled, all non-serialized fields keep their values. 

This will result in malfunction in classes. 

## What is the new behavior?
For disabled Domain Reload, I have added a function to every class that has static field which resets static fields to their default values. 

For disabled Scene Reload, I reset every non-serialized field in Zenject's MonoBehaviours.

This change is editor-only and has no effects on the final build.

All the changes are based on the documentations here:
https://docs.unity3d.com/Manual/DomainReloading.html
https://docs.unity3d.com/Manual/SceneReloading.html


## Does this introduce a breaking change?

- [ ] Yes
- [x] No