### PR TITLE
Fixed reflection baking in recent Unity versions

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Common/ReflectionBakingModuleEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Common/ReflectionBakingModuleEditor.cs
@@ -66,7 +66,9 @@ namespace Zenject.ReflectionBaking
 
             foreach (var typeDef in allTypes)
             {
-                if (_namespaceRegexes.Any() && !_namespaceRegexes.Any(x => x.IsMatch(typeDef.FullName)))
+                // Zenject namespace gets automatically added to the list of namespaces. 
+                // So to check if user added any other namespaces, we need to compare namespace count with 1
+                if (_namespaceRegexes.Count > 1 && !_namespaceRegexes.Any(x => x.IsMatch(typeDef.FullName)))
                 {
                     continue;
                 }

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
@@ -40,6 +40,9 @@ namespace Zenject.ReflectionBaking
 
         static void TryWeaveAssembly(string assemblyAssetPath)
         {
+            if (string.IsNullOrEmpty(assemblyAssetPath))
+                return;
+            
             var settings = ReflectionBakingInternalUtil.TryGetEnabledSettingsInstance();
 
             if (settings == null)

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
@@ -46,13 +46,15 @@ namespace Zenject.ReflectionBaking
             {
                 return;
             }
+            
+            var assemblyName = Path.GetFileNameWithoutExtension(assemblyAssetPath);
 
-            if (settings.AllGeneratedAssemblies && settings.ExcludeAssemblies.Contains(assemblyAssetPath))
+            if (settings.AllGeneratedAssemblies && settings.ExcludeAssemblies.Select(Path.GetFileNameWithoutExtension).Contains(assemblyName))
             {
                 return;
             }
 
-            if (!settings.AllGeneratedAssemblies && !settings.IncludeAssemblies.Contains(assemblyAssetPath))
+            if (!settings.AllGeneratedAssemblies && !settings.IncludeAssemblies.Select(Path.GetFileNameWithoutExtension).Contains(assemblyName))
             {
                 return;
             }
@@ -80,7 +82,6 @@ namespace Zenject.ReflectionBaking
                 return;
             }
 
-            var assemblyName = Path.GetFileNameWithoutExtension(assemblyAssetPath);
             var assembly = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(x => x.GetName().Name == assemblyName).OnlyOrDefault();
 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ZenjectReflectionBakingSettingsEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ZenjectReflectionBakingSettingsEditor.cs
@@ -203,7 +203,7 @@ namespace Zenject.ReflectionBaking
                 {
                     SerializedProperty current = listProperty.GetArrayElementAtIndex(k);
 
-                    if (path == current.stringValue)
+                    if (path == current.stringValue.Replace("/", "\\"))
                     {
                         foundMatch = true;
                         break;


### PR DESCRIPTION
I tried to not introduce any breaking changes in this PR. So I used some sub-optimal operations (Select form Linq) to do the job. Since the reflection baking code executed at design/build time, it shouldn't be a problem.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: #7 

## What is the current behavior?
Reflection baking doesn't work.

## What is the new behavior?
Fixed the reflection baking in the recent versions of Unity

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.1
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP