### PR TITLE
Add "OptionalExtras/Async.meta" for Package Manager

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Async.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Async.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eaa0c6cdaad0da24ea3d6ff3f330588a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Extenject can't be used with Package Manager Because `OptionalExtras/Async.meta` doesn't exist (Package Manager requires meta files of all assets).

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Extenject can be used with Package Manager

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- I've checked with git url `https://github.com/tsgcpp/Extenject.git?path=UnityProject/Assets/Plugins/Zenject#feature/add_async_meta_for_package_manager`

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.1
- [x] 2020.3 LTS
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.

@Mathijs-Bakker 
Could you confirm this PR?