### PR TITLE
Inject behavior for the existing UI Toolkit VisualElements available in the scene

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using Zenject.Internal;
 using UnityEngine.Events;
+using UnityEngine.UIElements;
 
 #if UNITY_EDITOR
 using UnityEditor;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs
@@ -290,6 +290,17 @@ namespace Zenject
                 _container.QueueForInject(instance);
             }
 
+            List<GameObject> rootObjectsInScene = new List<GameObject>();
+            gameObject.scene.GetRootGameObjects(rootObjectsInScene);
+            for (int i = 0; i < rootObjectsInScene.Count; i++)
+            {
+                UIDocument[] uiDocuments = rootObjectsInScene[i].GetComponentsInChildren<UIDocument>(true);
+                for (int j = 0; j < uiDocuments.Length; j++)
+                {
+                    uiDocuments[j].rootVisualElement.Query().ForEach(x => _container.QueueForInject(x));
+                }
+            }
+
             foreach (var decoratorContext in _decoratorContexts)
             {
                 decoratorContext.Initialize(_container);


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Extenject does no inject UI Toolkits VisualElement clases

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Extenject now does inject every UI Toolkits VisualElement added to the scene. It supports multiple UIDocuments.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [X] 2021.2
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [X] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
