### PR TITLE
Remove methods with unsupported attribute in Generic classes

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Factories/Pooling/Util/DictionaryPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Factories/Pooling/Util/DictionaryPool.cs
@@ -18,20 +18,6 @@ namespace Zenject
             get { return _instance; }
         }
 
-#if UNITY_EDITOR
-        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
-        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
-        static void ResetStaticValues()
-        {
-            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
-            {
-                return;
-            }
-            
-            _instance.Clear();
-        }
-#endif
-
         static void OnSpawned(Dictionary<TKey, TValue> items)
         {
             Assert.That(items.IsEmpty());

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Factories/Pooling/Util/HashSetPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Factories/Pooling/Util/HashSetPool.cs
@@ -17,20 +17,6 @@ namespace Zenject
         {
             get { return _instance; }
         }
-        
-#if UNITY_EDITOR
-        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
-        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
-        static void ResetStaticValues()
-        {
-            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
-            {
-                return;
-            }
-            
-            _instance.Clear();
-        }
-#endif
 
         static void OnSpawned(HashSet<T> items)
         {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Factories/Pooling/Util/ListPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Factories/Pooling/Util/ListPool.cs
@@ -10,20 +10,6 @@ namespace Zenject
         {
             OnDespawnedMethod = OnDespawned;
         }
-        
-#if UNITY_EDITOR
-        // Required for disabling domain reload in enter the play mode feature. See: https://docs.unity3d.com/Manual/DomainReloading.html
-        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
-        static void ResetStaticValues()
-        {
-            if (!UnityEditor.EditorSettings.enterPlayModeOptionsEnabled)
-            {
-                return;
-            }
-            
-            _instance.Clear();
-        }
-#endif
 
         public static ListPool<T> Instance
         {


### PR DESCRIPTION
* RuntimeInitializeOnLoadMethodAttribute is not supported on Generic classes.

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: #24 

*Create or search an issue here: [Extenject/Issues](https://github.com/Mathijs-Bakker/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
* A build on Android, iOS, or Desktop fails (check sample project attached to the issue)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- It was removed the same method `ResetStaticValues()` on each one of these generic classes (`HashSetPool`, `DictionaryPool`, and `ListPool`).
- These methods had the attribute [RuntimeInitializeOnLoadMethod](https://docs.unity3d.com/2021.2/Documentation/ScriptReference/RuntimeInitializeOnLoadMethodAttribute.html), which according to the error related to the issue isn't allowed on Generic classes.
- I checked that none of these methods weren't being called anyway when you press play on Unity Editor, thus not performing their intention which would be to clear the static instance of those classes.
    -  Other **non-generic** classes with similar methods (`ResetStaticValues()`) work as intended (e.g. `ProjectContext`.`ResetStaticValues()`).
    - Toggling either `EnterPlayModeSettings` or `ReloadDomain` won't help in making those methods being called (at `Edit` -> `Project Settings` -> `Editor`)
    - These methods were wrapped with the `UNITY_EDITOR` preprocessor tag before, thus the changes (if any) would be editor-only and have no effects on the final build.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

It could be interesting to check if we need to take any actions regarding this already [merged issue](https://github.com/Mathijs-Bakker/Extenject/pull/6), still, I believe the removal of this code would have no impact on that.

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.2.9f1
- [x] 2021.2.7f1
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
