### PR TITLE
Fixed prefab instantiation with Configurable Enter Play Mode

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenUtilInternal.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenUtilInternal.cs
@@ -262,7 +262,9 @@ namespace Zenject.Internal
         // without any of their Awake() methods firing.
         public static Transform GetOrCreateInactivePrefabParent()
         {
-            if(_disabledIndestructibleGameObject == null || (!Application.isPlaying && _disabledIndestructibleGameObject.scene != SceneManager.GetActiveScene()))
+            if(_disabledIndestructibleGameObject == null ||
+                (!Application.isPlaying && _disabledIndestructibleGameObject.scene != SceneManager.GetActiveScene()) ||
+                !_disabledIndestructibleGameObject.scene.isLoaded)
             {
                 var go = new GameObject("ZenUtilInternal_PrefabParent");
                 go.hideFlags = HideFlags.HideAndDontSave;


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/Mathijs-Bakker/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We encountered an issue where ZenjectIntegrationTestFixture destroys MainThreadDispatcher before ProjectContext, which leads to test failures when MainThreadDispatcher is used when disposing the context. This happens when Unity is configured to enter/exit play mode without a domain reload.

Under the hood a magical `_disabledIndestructibleGameObject` is used in the Unity Editor to instantiate prefabs in an inactive state. ProjectContext is one such prefab. The reference to this magical GameObject is stored in a static variable:
```
static GameObject _disabledIndestructibleGameObject;
```

After exiting play mode, this GameObject reference is still alive (null check returns false). The GameObject ends up in an unloaded scene named "null". Unity will happily instantiate prefabs into this null state.

When running a test that inherits from ZenjectIntegrationTestFixture, the hierarchy of the `DontDestroyOnLoad` scene will be incorrect, resulting in ProjectContext getting destroyed too early.

The issue is resolved when I trigger a domain reload by modifying a script, but returns when I enter and exit play mode again.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

After exiting play mode, a new GameObject will be created. ProjectContext and other prefabs will always be instantiated in the correct place (the `DontDestroyOnLoad` scene).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- This change only effects the behaviour in the Unity Editor.

On which Unity version has this been tested?
--------------------------------------------
- [x] 2020.3 LTS
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
