### PR TITLE
Added check to reflection baking to skip compiler generated classes.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/ReflectionBaking/Common/ReflectionBakingModuleEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/ReflectionBaking/Common/ReflectionBakingModuleEditor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using ModestTree;
 using Zenject.Internal;
@@ -79,7 +80,10 @@ namespace Zenject.ReflectionBaking
                 {
                     Log.Warn("Could not find actual type for type '{0}', skipping", typeDef.FullName);
                     continue;
-                }
+                } 
+                
+                if (actualType.HasAttribute<CompilerGeneratedAttribute>())
+                    continue;
 
                 if (TryEditType(typeDef, actualType))
                 {


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number
Issue Number: N/A

## What is the current behavior?
When there are libraries which create compiler generated classes such as UniTask, reflection baking crashes because it's trying to analyze a type which it shouldn't modify.

## What is the new behavior?
Reflection baking skips classes which have "CompilerGeneratedAttribute" on them.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP