### PR TITLE
Added Find Sibling MonoInstallers to all Contexts.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/Editors/ContextEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/Editors/ContextEditor.cs
@@ -1,3 +1,5 @@
+using UnityEditor;
+
 #if !ODIN_INSPECTOR
 
 namespace Zenject
@@ -5,6 +7,8 @@ namespace Zenject
     [NoReflectionBaking]
     public class ContextEditor : UnityInspectorListEditor
     {
+        private SerializedProperty _findSiblingInstallers;
+
         protected override string[] PropertyNames
         {
             get
@@ -42,6 +46,20 @@ namespace Zenject
                     "Drag any prefabs that contain a MonoInstaller on them here",
                 };
             }
+        }
+
+        public override void OnEnable()
+        {
+            base.OnEnable();
+            
+            _findSiblingInstallers = serializedObject.FindProperty("_findSiblingMonoInstallers");
+        }
+
+        protected override void OnGui()
+        {
+            base.OnGui();
+            
+            EditorGUILayout.PropertyField(_findSiblingInstallers);
         }
     }
 }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/Context.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using ModestTree;
 using UnityEngine;
 using UnityEngine.Serialization;
+using Zenject.Internal;
 #if UNITY_EDITOR
 using UnityEditor;
 
@@ -22,6 +23,9 @@ namespace Zenject
         List<MonoInstaller> _monoInstallers = new List<MonoInstaller>();
 
         [SerializeField] List<MonoInstaller> _installerPrefabs = new List<MonoInstaller>();
+
+        [Tooltip("If checked, this context will automatically get all MonoInstallers attached to the current gameObject by calling GetComponents. This is useful for when you are using Prefab Variants and you cannot easily modify the list of installers.")] [SerializeField]
+        bool _findSiblingMonoInstallers;
 
         List<InstallerBase> _normalInstallers = new List<InstallerBase>();
         List<Type> _normalInstallerTypes = new List<Type>();
@@ -162,6 +166,26 @@ namespace Zenject
 
         protected void InstallInstallers()
         {
+            if (_findSiblingMonoInstallers)
+            {
+                List<MonoInstaller> siblingInstallers = ZenPools.SpawnList<MonoInstaller>();
+
+                try
+                {
+                    GetComponents(siblingInstallers);
+
+                    foreach (MonoInstaller m in siblingInstallers)
+                    {
+                        if (!_monoInstallers.Contains(m))
+                            _monoInstallers.Add(m);
+                    }
+                }
+                finally
+                {
+                    ZenPools.DespawnList(siblingInstallers);
+                }
+            }
+
             InstallInstallers(
                 _normalInstallers, _normalInstallerTypes, _scriptableObjectInstallers, _monoInstallers,
                 _installerPrefabs);


### PR DESCRIPTION
In the current version you have to manually specify installers that you want to have run on a specific context in a list. This doesn't work very well with prefab variants.  

For example, If you have prefab "Base" and prefab "Variant", If you modify the installer list on "Variant", the whole list will be marked as overridden. As a result, if you add any new installer to installer list in "Base", they will not automatically be added to the list of installers in "Variant". You have to go through all variants and add the installer manually. 

With this change, you no longer need to change the installer list. Each installer will get all attached MonoInstallers automatically.

**Is this a breaking change?** No, this feature is opt-in.