### PR TITLE
Added ability to set the instance of ProjectContext and initialize it manually

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/ProjectContext.cs
@@ -59,12 +59,24 @@ namespace Zenject
 
                 return _instance;
             }
+            set
+            {
+                Assert.IsNull(_instance, "ProjectContext already has an instance. Cannot replace ProjectContext after one is created.");
+                Assert.IsNotNull(value);
+                _instance = value;
+            }
         }
 
         public static bool ValidateOnNextRun
         {
             get;
             set;
+        }
+        
+        public ZenjectSettings Settings
+        {
+            get => _settings;
+            set => _settings = value;
         }
 
         public override IEnumerable<GameObject> GetRootGameObjects()
@@ -214,7 +226,7 @@ namespace Zenject
             }
         }
 
-        void Initialize()
+        public void Initialize()
         {
             // Do this as early as possible before any type analysis occurs
             ReflectionTypeAnalyzer.ConstructorChoiceStrategy = _settings.ConstructorChoiceStrategy;

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/ProjectContext.cs
@@ -76,7 +76,11 @@ namespace Zenject
         public ZenjectSettings Settings
         {
             get => _settings;
-            set => _settings = value;
+            set
+            {
+                Assert.IsNull(_container, "You cannot change settings after ProjectContext initialization.");
+                _settings = value;
+            }
         }
 
         public override IEnumerable<GameObject> GetRootGameObjects()
@@ -228,11 +232,11 @@ namespace Zenject
 
         public void Initialize()
         {
+            Assert.IsNull(_container);
+            
             // Do this as early as possible before any type analysis occurs
             ReflectionTypeAnalyzer.ConstructorChoiceStrategy = _settings.ConstructorChoiceStrategy;
-
-            Assert.IsNull(_container);
-
+            
             if (Application.isEditor)
             {
                 TypeAnalyzer.ReflectionBakingCoverageMode = _editorReflectionBakingCoverageMode;


### PR DESCRIPTION
Some unit tests require specific settings for ProjectContext. The current implementation of ProjectContext doesn't allow initialization any other way that having the prefab with exact name in resources folder. 

This makes it impossible to have two unit tests which need two different versions of ProjectContext.

With this change, it's possible to set the ProjectContext instance manually and call Initialize.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No