### PR TITLE
MemoryPool checks if the item it's returning is null or not.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenUtilInternal.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenUtilInternal.cs
@@ -34,9 +34,20 @@ namespace Zenject.Internal
         // expected
         // In those cases you can use this function which will also
         // work with non-unity objects
-        public static bool IsNull(System.Object obj)
+        public static bool IsNull(object obj)
         {
-            return obj == null || obj.Equals(null);
+            if (obj == null || obj.Equals(null))
+                return true;
+            
+#if !NOT_UNITY3D
+            // This is very weird but sometimes when you check a component's value to see if it's null or not,
+            // the component's null check shows the component is valid but the object is actually destroyed/invalid.
+            // So as an additional measure we check for the gameObject as well.
+            if (obj is Component c)
+                return c.gameObject == null;
+#endif
+
+            return false;
         }
 
 #if UNITY_EDITOR

--- a/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool.meta
+++ b/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9818a43d599f4a9991a4a65967ac3d03
+timeCreated: 1652478565

--- a/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/FooMemoryPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/FooMemoryPool.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace Zenject.Tests.IntegrationTests.MemoryPool
+{
+    public class FooMemoryPool : MonoBehaviour
+    {
+        public class Pool : MonoMemoryPool<FooMemoryPool>
+        {
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/FooMemoryPool.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/FooMemoryPool.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 90f190932c554afa97d669072271734d
+timeCreated: 1652478880

--- a/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/TestMemoryPool.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/TestMemoryPool.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Zenject.Internal;
+
+namespace Zenject.Tests.IntegrationTests.MemoryPool
+{
+    [TestFixture]
+    public class TestMemoryPool : ZenjectIntegrationTestFixture
+    {
+        [UnityTest]
+        public IEnumerator TestDestroyAnInactiveItemInPool()
+        {
+            PreInstall();
+            Container.BindMemoryPool<FooMemoryPool, FooMemoryPool.Pool>()
+                .FromNewComponentOnNewGameObject();
+            PostInstall();
+
+            var pool = Container.Resolve<FooMemoryPool.Pool>();
+            FooMemoryPool f1 = pool.Spawn();
+            FooMemoryPool f2 = pool.Spawn();
+            FooMemoryPool f3 = pool.Spawn();
+
+            Assert.IsFalse(ZenUtilInternal.IsNull(f1));
+            Assert.IsFalse(ZenUtilInternal.IsNull(f2));
+            Assert.IsFalse(ZenUtilInternal.IsNull(f3));
+
+            pool.Despawn(f1);
+            pool.Despawn(f2);
+            pool.Despawn(f3);
+
+            yield return null;
+            GameObject.Destroy(f1.gameObject);
+            GameObject.Destroy(f2.gameObject);
+            yield return null;
+
+            f1 = pool.Spawn();
+            f2 = pool.Spawn();
+            f3 = pool.Spawn();
+
+            Assert.IsFalse(ZenUtilInternal.IsNull(f1));
+            Assert.IsFalse(ZenUtilInternal.IsNull(f2));
+            Assert.IsFalse(ZenUtilInternal.IsNull(f3));
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/TestMemoryPool.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/Tests/IntegrationTests/MemoryPool/TestMemoryPool.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aad8f6f2e02a4413b4ccade46c46088f
+timeCreated: 1652478719


### PR DESCRIPTION
Added a simple check to pool to make sure that pool doesn't return or accept null items.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
1. You return an object to pool
2. Destroy the object
3. Pool doesn't check if the object is destroyed and will return the null object in `Spawn` method.

## What is the new behavior?
Pool will check if the item that is about to be returned is null or not.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021 LTS

**Scripting backend:**
- [ ] Mono
- [ ] IL2CPP