### PR TITLE
Ignore UnityEngine classes from TypeAnalyzer

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/TypeAnalyzer.cs
@@ -232,8 +232,12 @@ namespace Zenject
         public static bool ShouldSkipTypeAnalysis(Type type)
         {
             return type == null || type.IsEnum() || type.IsArray || type.IsInterface()
-                || type.ContainsGenericParameters() || IsStaticType(type)
-                || type == typeof(object);
+                   || type.ContainsGenericParameters() || IsStaticType(type)
+                   || type == typeof(object)
+#if !NOT_UNITY3D
+                   || (type.Namespace != null && type.Namespace.Contains("UnityEngine"))
+#endif
+                ;
         }
 
         static bool IsStaticType(Type type)


### PR DESCRIPTION
With this PR, `TypeAnalyzer` will not try to analyze `UnityEngine` classes for injections.

I believe most of the use cases for classes inside `UnityEngine` namespace do not involve resolving through dependency injection. They also don't receive injections. 

I created issue #8 to discuss this and no one mentioned if their workflows are affected. I think this is a safe change.

The benefit of ignoring these classes is for when we are getting injectable MonoBehaviours in SceneContext and GameObjectContext.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number #8 

## What is the current behavior?
TypeAnalyzer tries to analyze UnityEngine classes.

## What is the new behavior?
TypeAnalyzer ignores UnityEngine classes.

## Does this introduce a breaking change?
No