### PR TITLE
Readme: Fix link anchors for ScriptableObjectInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,7 +1091,7 @@ There are three ways to do this.
 
 1. **Prefabs within Resources folder**.  You can also place your installer prefabs underneath a Resoures folder and install them directly from code by using the Resources path.  For details on usage see [here](#runtime-parameters-for-installers).
 
-Another option in addition to `MonoInstaller` and `Installer<>` is to use `ScriptableObjectInstaller` which has some unique advantages (especially for settings) - for details see [here](#scriptableobject-installer).
+Another option in addition to `MonoInstaller` and `Installer<>` is to use `ScriptableObjectInstaller` which has some unique advantages (especially for settings) - for details see [here](#scriptable-object-installer).
 
 When calling installers from other installers it is common to want to pass parameters into it.  See [here](#runtime-parameters-for-installers) for details on how that is done.
 
@@ -1319,7 +1319,7 @@ public class TestInstaller : MonoInstaller<TestInstaller>
 
 Now, if we run our scene we can change the speed value to tune the Foo class in real time.
 
-Another (arguably better) way to do this is to use `ScriptableObjectInstaller` instead of `MonoInstaller,` which have the added advantage that you can change your settings at runtime and have those changes automatically persist when play mode is stopped.  See [here](#scriptableobject-installer) for details.
+Another (arguably better) way to do this is to use `ScriptableObjectInstaller` instead of `MonoInstaller,` which have the added advantage that you can change your settings at runtime and have those changes automatically persist when play mode is stopped.  See [here](#scriptable-object-installer) for details.
 
 ## Object Graph Validation
 


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/Mathijs-Bakker/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [ ] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
