### PR TITLE
Fixed exception on Resources.Load

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Providers/PrefabProviders/PrefabProviderResource.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Providers/PrefabProviders/PrefabProviderResource.cs
@@ -17,7 +17,7 @@ namespace Zenject
 
         public UnityEngine.Object GetPrefab(InjectContext context)
         {
-            var prefab = (GameObject)Resources.Load(_resourcePath);
+            var prefab = Resources.Load<GameObject>(_resourcePath);
 
             Assert.That(prefab != null,
                 "Expected to find prefab at resource path '{0}'", _resourcePath);


### PR DESCRIPTION
This is a naive fix for a bug i faced just now. When you load a prefab resource from a directory where you have a script with the same name, the wrong file is loaded and the late cast breaks with an invalid cast exception.

for the illustration, here is my directory listing:

Parasites.cs <- this one is loaded instead of the prefab...
Parasites.prefab

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/Mathijs-Bakker/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [ ] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
