### PR TITLE
Replaced Resources.FindObjectsOfTypeAll by FindObjectsOfType

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/Context.cs
@@ -286,12 +286,14 @@ namespace Zenject
                 }
             }
 
-            // We'd prefer to use GameObject.FindObjectsOfType<ZenjectBinding>() here
-            // instead but that doesn't find inactive gameobjects
             // TODO: Consider changing this
             // Maybe ZenjectBinding could add itself to a registry class on Awake/OnEnable
             // then we could avoid calling the slow Resources.FindObjectsOfTypeAll here
+#if UNITY_2020_1_OR_NEWER
+            foreach (var binding in FindObjectsOfType<ZenjectBinding>(true))
+#else
             foreach (var binding in Resources.FindObjectsOfTypeAll<ZenjectBinding>())
+#endif
             {
                 if (binding == null)
                 {


### PR DESCRIPTION
As of Unity version 2020.1, it is possible to use FindObjectsOfType<ZenjectBinding>(true) to also find inactive objects in the hierarchy This avoid to search additional data we're not interested in, and closes a comment saying "we would like to it this way". 

Well now we do.

Change has been tested on Unity 2020.3 LTS and 2021.2 using Mono build