### PR TITLE
Add new overloads for ZenjectSceneLoader

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenjectSceneLoader.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Util/ZenjectSceneLoader.cs
@@ -54,7 +54,7 @@ namespace Zenject
             // we can't do that in this case since the scene isn't loaded until the next frame
         }
 
-            public AsyncOperation LoadSceneAsync(
+        public AsyncOperation LoadSceneAsync(
             string sceneName,
             LoadSceneMode loadMode = LoadSceneMode.Single,
             Action<DiContainer> extraBindings = null,
@@ -67,6 +67,42 @@ namespace Zenject
                 "Unable to load scene '{0}'", sceneName);
 
             return SceneManager.LoadSceneAsync(sceneName, loadMode);
+        }
+
+        public void LoadScene(
+            string sceneName,
+            LoadSceneParameters loadSceneParameters,
+            Action<DiContainer> extraBindings = null,
+            LoadSceneRelationship containerMode = LoadSceneRelationship.None,
+            Action<DiContainer> extraBindingsLate = null)
+        {
+            PrepareForLoadScene(loadSceneParameters.loadSceneMode, extraBindings, extraBindingsLate, containerMode);
+
+            Assert.That(Application.CanStreamedLevelBeLoaded(sceneName),
+                "Unable to load scene '{0}'", sceneName);
+
+            SceneManager.LoadScene(sceneName, loadSceneParameters);
+
+            // It would be nice here to actually verify that the new scene has a SceneContext
+            // if we have extra binding hooks, or LoadSceneRelationship != None, but
+            // we can't do that in this case since the scene isn't loaded until the next frame
+        }
+
+#if UNITY_2018_3_OR_NEWER
+
+        public AsyncOperation LoadSceneAsync(
+            string sceneName,
+            LoadSceneParameters loadSceneParameters,
+            Action<DiContainer> extraBindings = null,
+            LoadSceneRelationship containerMode = LoadSceneRelationship.None,
+            Action<DiContainer> extraBindingsLate = null)
+        {
+            PrepareForLoadScene(loadSceneParameters.loadSceneMode, extraBindings, extraBindingsLate, containerMode);
+
+            Assert.That(Application.CanStreamedLevelBeLoaded(sceneName),
+                "Unable to load scene '{0}'", sceneName);
+
+            return SceneManager.LoadSceneAsync(sceneName, loadSceneParameters);
         }
 
         void PrepareForLoadScene(
@@ -113,6 +149,8 @@ namespace Zenject
             SceneContext.ExtraBindingsLateInstallMethod = extraBindingsLate;
         }
 
+#endif
+
         public void LoadScene(
             int sceneIndex,
             LoadSceneMode loadMode = LoadSceneMode.Single,
@@ -146,6 +184,43 @@ namespace Zenject
 
             return SceneManager.LoadSceneAsync(sceneIndex, loadMode);
         }
+
+#if UNITY_2018_3_OR_NEWER
+
+        public void LoadScene(
+            int sceneIndex,
+            LoadSceneParameters loadSceneParameters,
+            Action<DiContainer> extraBindings = null,
+            LoadSceneRelationship containerMode = LoadSceneRelationship.None,
+            Action<DiContainer> extraBindingsLate = null)
+        {
+            PrepareForLoadScene(loadSceneParameters.loadSceneMode, extraBindings, extraBindingsLate, containerMode);
+
+            Assert.That(Application.CanStreamedLevelBeLoaded(sceneIndex),
+                "Unable to load scene '{0}'", sceneIndex);
+
+            SceneManager.LoadScene(sceneIndex, loadSceneParameters);
+
+            // It would be nice here to actually verify that the new scene has a SceneContext
+            // if we have extra binding hooks, or LoadSceneRelationship != None, but
+            // we can't do that in this case since the scene isn't loaded until the next frame
+        }
+
+        public AsyncOperation LoadSceneAsync(
+            int sceneIndex,
+            LoadSceneParameters loadSceneParameters,
+            Action<DiContainer> extraBindings = null,
+            LoadSceneRelationship containerMode = LoadSceneRelationship.None,
+            Action<DiContainer> extraBindingsLate = null)
+        {
+            PrepareForLoadScene(loadSceneParameters.loadSceneMode, extraBindings, extraBindingsLate, containerMode);
+
+            Assert.That(Application.CanStreamedLevelBeLoaded(sceneIndex),
+                "Unable to load scene '{0}'", sceneIndex);
+
+            return SceneManager.LoadSceneAsync(sceneIndex, loadSceneParameters);
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
Add support to ZenjectSceneLoader for loading scenes using SceneManager methods using LoadSceneParameters instead of just LoadSceneMode. SceneManager methods were added in Unity 2018.3.

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/Mathijs-Bakker/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Currently ZenjectSceneLoader only supports loading a scene using SceneManager.LoadScene methods which accept LoadSceneMode as argument.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added support to ZenjectSceneLoader for new SceneManager.LoadScene methods added in Unity 2018.3 which use LoadSceneParameters instead of LoadSceneMode. Change allows better configuration of loaded scene as it is possible to define scene's local physics mode.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.3 LTS
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
