### PR TITLE
Unbind references from container on scene unload

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Install/Contexts/SceneContext.cs
@@ -136,6 +136,11 @@ namespace Zenject
             }
         }
 
+        protected virtual void OnDestroy()
+        {
+            _container.UnbindAll();
+        }
+
 #if UNITY_EDITOR
         protected override void ResetInstanceFields()
         {


### PR DESCRIPTION
Zenject doesn't properly clear reference from scene container when scene is unloaded. This results in memory leak when loading and unloading scenes.

Fixed the issue by unbinding all reference from scene container when SceneContext component is destroyed.

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/Mathijs-Bakker/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: 246 in Zenject repository

https://github.com/modesttree/Zenject/issues/246

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Currently it is possible that not all references are unbound when scene is unload. This can noticeable memory leaks depending on what has been referenced.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When SceneContext is destroyed all the bindings in its container are unbound. This ensures that no references are left hanging when SceneContext is no longer used.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.3 LTS
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
