### PR TITLE
ResolveAll generics with InjectSources

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Main/DiContainer.cs
@@ -2469,10 +2469,20 @@ namespace Zenject
         {
             return (List<TContract>)ResolveAll(typeof(TContract));
         }
+        
+        public List<TContract> ResolveAll<TContract>(InjectSources injectSources)
+        {
+            return (List<TContract>)ResolveAll(typeof(TContract), injectSources);
+        }
 
         public IList ResolveAll(Type contractType)
         {
             return ResolveIdAll(contractType, null);
+        }
+        
+        public IList ResolveAll(Type contractType, InjectSources injectSources)
+        {
+            return ResolveIdAll(contractType, null, injectSources);
         }
 
         public List<TContract> ResolveIdAll<TContract>(object identifier)
@@ -2486,6 +2496,17 @@ namespace Zenject
             {
                 context.Identifier = identifier;
                 context.Optional = true;
+                return ResolveAll(context);
+            }
+        }
+        
+        public IList ResolveIdAll(Type contractType, object identifier, InjectSources injectSources)
+        {
+            using (var context = ZenPools.SpawnInjectContext(this, contractType))
+            {
+                context.Identifier = identifier;
+                context.Optional = true;
+                context.SourceType = injectSources;
                 return ResolveAll(context);
             }
         }

--- a/UnityProject/Assets/Plugins/Zenject/Tests/UnitTests/Editor/Bindings/TestFromResolve.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Tests/UnitTests/Editor/Bindings/TestFromResolve.cs
@@ -172,6 +172,22 @@ namespace Zenject.Tests.Bindings
 
             Assert.IsEqual(subContainer.Resolve<IFoo>(), foo1);
         }
+        
+        [Test]
+        public void TestResolveAllWithInjectSource()
+        {
+            var foo = new Foo();
+            var secondFoo = new SecondFoo();
+
+            Container.BindInterfacesTo<Foo>().FromInstance(foo);
+
+            var subContainer = Container.CreateSubContainer();
+            subContainer.BindInterfacesTo<SecondFoo>().FromInstance(secondFoo);
+            
+            Assert.IsEqual(subContainer.ResolveAll<IFoo>(InjectSources.Any).Count, 2);
+            Assert.IsEqual(subContainer.ResolveAll<IFoo>(InjectSources.Local).Count, 1);
+        }
+
 
         [Test]
         public void TestInjectSource2()
@@ -201,6 +217,10 @@ namespace Zenject.Tests.Bindings
         }
 
         class Foo : IFoo, IBar
+        {
+        }
+
+        class SecondFoo : IFoo
         {
         }
     }


### PR DESCRIPTION
Feature

Opportunity to use something like ResolveAll<IDisposable>() with InjectSource ResolveAll generics with InjectSources

I love use container.ResolveAll<T> instead any other API but in sub containers i cant use it with local group before.

After changes i can;
![Снимок экрана 2023-02-08 121320](https://user-images.githubusercontent.com/65606483/217472461-caae65ff-755b-4911-a3d2-5225774b30a2.png)

Just some Quality of life changes
